### PR TITLE
add kvazar content exploring link

### DIFF
--- a/_includes/layout.liquid
+++ b/_includes/layout.liquid
@@ -73,6 +73,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/_includes/layout_.liquid
+++ b/_includes/layout_.liquid
@@ -65,6 +65,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/_includes/layout_md.liquid
+++ b/_includes/layout_md.liquid
@@ -77,6 +77,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/blog.html
+++ b/docs/blog.html
@@ -121,6 +121,7 @@ Image by <a href="https://pixabay.com/users/theglassdesk-149631/?utm_source=link
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -300,6 +300,7 @@ kevacoin-cli keva_filter NfjHmcWxHndbfMRG7FeXWtmBEaRp896wBC "first*"
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/elecn.html
+++ b/docs/elecn.html
@@ -162,6 +162,7 @@ python3.7 electrumx_server
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -173,6 +173,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/how_to_get_rich_abolutely_quick.html
+++ b/docs/how_to_get_rich_abolutely_quick.html
@@ -78,6 +78,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
             <div><a href="index_zh.html" class="kva-footer-link">中文</a></div>
           </div>

--- a/docs/how_to_get_rich_even_quicker.html
+++ b/docs/how_to_get_rich_even_quicker.html
@@ -78,6 +78,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
             <div><a href="index_zh.html" class="kva-footer-link">中文</a></div>
           </div>

--- a/docs/how_to_get_rich_quick.html
+++ b/docs/how_to_get_rich_quick.html
@@ -79,6 +79,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
             <div><a href="index_zh.html" class="kva-footer-link">中文</a></div>
           </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,7 +54,7 @@
       </div>
     </nav>
 
-    
+
 <main role="main">
   <div class="jumbotron">
     <div class="layer"></div>
@@ -386,6 +386,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/index_.html
+++ b/docs/index_.html
@@ -51,7 +51,7 @@
       </div>
     </nav>
 
-    
+
 <main role="main">
   <div class="jumbotron">
     <div class="layer"></div>
@@ -368,6 +368,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/ipfs_mobile.html
+++ b/docs/ipfs_mobile.html
@@ -105,6 +105,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/ipfs_mobile_android_support.html
+++ b/docs/ipfs_mobile_android_support.html
@@ -88,6 +88,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/keva_access_control.html
+++ b/docs/keva_access_control.html
@@ -93,6 +93,7 @@ Image by <a href="https://pixabay.com/users/12019-12019/?utm_source=link-attribu
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/keva_combined_views.html
+++ b/docs/keva_combined_views.html
@@ -96,6 +96,7 @@ Image by <a href="https://pixabay.com/users/geralt-9301/?utm_source=link-attribu
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/keva_electrumx.html
+++ b/docs/keva_electrumx.html
@@ -165,6 +165,7 @@ Image by <a href="https://pixabay.com/users/Cleverpix-2508959/?utm_source=link-a
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/mining.html
+++ b/docs/mining.html
@@ -85,6 +85,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/on_chain.html
+++ b/docs/on_chain.html
@@ -87,6 +87,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -56,7 +56,7 @@
 
     <main role="main" class="mt-5 mb-5">
       <div class="container kva-documentation">
-    
+
   <section id="privacy" class="main-content">
     <div class="container-sub">
       <h3>Privacy Policy</h3>
@@ -176,6 +176,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -54,7 +54,7 @@
       </div>
     </nav>
 
-    
+
 <main role="main" class="mt-5 px-2">
   <div class="container">
 
@@ -111,6 +111,7 @@
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/tutorial_api.html
+++ b/docs/tutorial_api.html
@@ -54,7 +54,7 @@
       </div>
     </nav>
 
-    
+
 <main role="main" class="mt-5 mb-5 px-2">
   <div class="container">
     <div class="row mb-2">
@@ -175,6 +175,7 @@ kevacoin-cli keva_filter NfjHmcWxHndbfMRG7FeXWtmBEaRp896wBC "first*"
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>

--- a/docs/tutorial_solo_mining.html
+++ b/docs/tutorial_solo_mining.html
@@ -151,6 +151,7 @@ VFgAsW4SP7GtMwb4Uvf9Z6nZ4j8qWbs5fV
             <p class="kva-footer-title">Resources</p>
             <div><a href="https://explorer.kevacoin.org" class="kva-footer-link">Block Explorer 1</a></div>
             <div><a href="https://insight.kevacoin.org" class="kva-footer-link">Block Explorer 2</a></div>
+            <div><a href="https://kvazar.today" class="kva-footer-link">Content Explorer</a></div>
             <div><a href="whitepaper.pdf" class="kva-footer-link">White Paper</a></div>
           </div>
         </div>


### PR DESCRIPTION
One year before I have created open source content-oriented explorer platform
https://kvazar.today
https://github.com/kvazar-network/webapp/tree/sqlite

So why not to share it with community, who use kevacoin blockchain for the blogging needs.

p.s. also, another solution available, called [galaxyos](http://galaxyos.io/), just it not so useful because not support content search, RSS, and other human-readable features. what about add this resource too?
